### PR TITLE
[Improvement] - replace "case" with "description"

### DIFF
--- a/mobile/src/pages/Detail/index.js
+++ b/mobile/src/pages/Detail/index.js
@@ -67,8 +67,8 @@ export default function Details() {
           {incident.name} de {incident.city}/{incident.uf}
         </IValue>
 
-        <IProperty>CASO:</IProperty>
-        <IValue>{incident.title}</IValue>
+        <IProperty>DESCRIÇÃO:</IProperty>
+        <IValue>{incident.description}</IValue>
 
         <IProperty>VALOR:</IProperty>
         <IValue>


### PR DESCRIPTION
# Motivation:

The description field belongs to the details screen.

_______________________________________________________________________________________________________

# Solution:

As the description field was not added on the screen, I opened this pull request to contribute to the application

_______________________________________________________________________________________________________

# Assignment:

- [x] Replace the "case" field with "description" and the "incident.tile" field with "incident.description"

##### Hope this helps!
